### PR TITLE
Fix broken postgres query

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ your container:
   - `DB_HOST`
   - `DB_PORT`
     - default: `3306` if `DB_DRIVER` == 'mysql'
-    - default: `5432` if `DB_DRIVER` == 'pdsql'
+    - default: `5432` if `DB_DRIVER` == 'pgsql'
   - `DB_NAME`
     - default: `drupal`
+    - default: `postgres` if `DB_DRIVER == pgsql`
   - `DB_USER`
     - default: `root` if `DB_DRIVER` == 'mysql'
-    - default: `postgres` if `DB_DRIVER` == 'pdsql'
+    - default: `postgres` if `DB_DRIVER` == 'pgsql'
   - `DB_PASS`
 
 ### Postgres

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,8 @@ function run_scripts () {
 	SCRIPTS=$(find "$SCRIPTS_DIR" -type f -uid 0 -executable -regex "$SCRIPT_FILES_PATTERN" | sort)
 	if [ -n "$SCRIPTS" ] ; then
 		echo "=>> $1-scripts:"
-	    for script in $SCRIPTS ; do
-	        echo "=> $script"
+		for script in $SCRIPTS ; do
+			echo "=> $script"
 			. "$script"
 	    done
 	fi
@@ -44,6 +44,7 @@ elif [ -n "$POSTGRES_PORT_5432_TCP" ]; then
 		echo >&2 "  Connecting to DB_HOST ($DB_HOST)"
 		echo >&2 "  instead of the linked postgres container."
 	fi
+	: ${DB_NAME:='postgres'}
 fi
 
 if [ -z "$DB_HOST" ]; then
@@ -125,10 +126,17 @@ fi
 if [[ $DB_DRIVER == "mysql" ]]; then
 	drush sql-query "SHOW DATABASES LIKE '${DB_NAME}';" > /dev/null || TABLE_EXISTS=$?
 elif [[ $DB_DRIVER == "pgsql" ]]; then
-	drush sql-query '\l' > /dev/null || TABLE_EXISTS=$?
+	tmpfile=$(mktemp);
+	drush sql-query --result-file=$tmpfile '\dt' > /dev/null;
+	if [[ -s "$tmpfile" ]]; then
+		TABLE_EXISTS=0;
+	else
+		TABLE_EXISTS=1;
+	fi
+	rm $tmpfile
 fi
 
-if ! $TABLE_EXISTS; then
+if [[ $TABLE_EXISTS -ne 0 ]]; then
 	run_scripts setup
 	echo "=> Done installing site!"
 	if [ $EXTRA_SETUP_SCRIPT ]; then


### PR DESCRIPTION
- Fixes #25
- Fixes broken table_exists check
- DB_NAME defaults to 'postgres' if not otherwise set, to maintain ease
  of deployment for the postgres folks. Our database comes with a
  default database+schema (equivalent to a default mysql database)
  already created.
- Readme is updated fixing typos on DB_DRIVER and documenting DB_NAME
  default under postgres